### PR TITLE
🚑 update peer deps to gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react-netlify-identity-gotrue": "^0.3.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^3.0.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
# Description

`gatsby-plugin-netlify-identity-gotrue` won't work with Gatsby V3 bc it lists v2 as a peer dependency.

Updating to Gatsby V3 should hopefully just be a matter of updating the peer deps in the package repo.

[Gatsby3.0 Migration docs](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3#updating-community-plugins)

[Updating dependencies
](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3#updating-your-dependencies
)

Please update peer deps and let us know what else we can do to help. 👍

Fixes # (issue)

```
npm ERR! Could not resolve dependency:
npm ERR! peer gatsby@"^2.0.0" from gatsby-plugin-netlify-identity-gotrue@0.3.5
npm ERR! node_modules/gatsby-plugin-netlify-identity-gotrue
npm ERR!   gatsby-plugin-netlify-identity-gotrue@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
